### PR TITLE
Add G6 to the graphing library options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This is a list of known graph drawing libraries. See [a website with interactive
 * [mbostock/d3](https://github.com/mbostock/d3) - A JavaScript visualization library for HTML and SVG. http://d3js.org
 * [samizdatco/arbor](https://github.com/samizdatco/arbor) - a graph visualization library using web workers and jQuery http://arborjs.org
 * [strathausen/dracula](https://github.com/strathausen/dracula) - JavaScript browser based layout and representation of connected graphs. http://www.graphdracula.net
+* [antvis/g6](https://github.com/antvis/g6) - G6: A Graph Visualization Framework in TypeScript.
 
 If you find something missing, please let me know.
 


### PR DESCRIPTION
G6 is a library for displaying network graphs and it especially exceeds for Dagre diagrams.